### PR TITLE
Restore scenario card activation behaviour

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,24 +51,45 @@
 .kpis{display:grid; grid-template-columns:repeat(4,1fr); gap:12px;} @media(max-width:900px){.kpis{grid-template-columns:repeat(2,1fr);} } .kpi{background:#0f1930; border:1px solid var(--border); border-radius:12px; padding:12px} .kpi .label{font-size:12px; color:var(--muted)} .kpi .value{font-size:18px; font-weight:700; margin-top:6px} .kpi.good .value{color:var(--ok)} .kpi.warn .value{color:var(--warn)} .kpi.bad .value{color:var(--danger)}
 
 .twocol{display:grid; grid-template-columns:1fr 1fr; gap:10px} .row{display:grid; grid-template-columns: 1.2fr .8fr; gap:10px; margin-bottom:8px} .row label{display:flex; align-items:center; gap:6px; color:var(--muted)} input[type=number], input[type=text]{ width:100%; box-sizing:border-box; padding:10px 10px; border-radius:10px; border:1px solid var(--border); background:#0a1324; color:var(--text); } input[type=number]::placeholder{color:#5f6d88}
+  .form-field{display:flex; flex-direction:column; gap:6px; margin-top:10px;}
+  .form-field:first-of-type{margin-top:0;}
+  .form-field label{color:var(--muted); font-size:12px;}
+  textarea{width:100%; box-sizing:border-box; padding:10px; border-radius:10px; border:1px solid var(--border); background:#0a1324; color:var(--text); font:inherit; resize:vertical; min-height:72px;}
+  textarea::placeholder{color:#5f6d88;}
 
 table{width:100%; border-collapse:collapse;} thead th{position:sticky; top:0; background:#0a1426; border-bottom:1px solid var(--border); padding:10px; font-size:12px; color:var(--muted); text-align:left} tbody td{border-bottom:1px dashed #1d2b47; padding:8px} tfoot td{border-top:1px solid var(--border); padding:10px; font-weight:700} .actions{display:flex; gap:8px; flex-wrap:wrap} .right{margin-left:auto} .tag{display:inline-block; font-size:11px; padding:2px 8px; border-radius:999px; border:1px solid var(--border); color:var(--muted)} .pill{display:inline-flex; gap:6px; align-items:center; padding:6px 10px; border-radius:999px; background:#0e182b; border:1px solid var(--border); color:var(--muted);} .muted{color:var(--muted)} details{border:1px dashed var(--border); padding:10px; border-radius:12px;} details[open]{background:#0b162c} details summary{cursor:pointer}
 
   .footer-note{color:#7d8dad; font-size:12px; margin-top:14px} .small{font-size:12px} .mono{font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace} .align-right{text-align:right} .nowrap{white-space:nowrap}
 
-  .scenario-grid{display:grid; gap:12px; grid-template-columns:repeat(auto-fit, minmax(260px, 1fr)); margin-top:12px;}
-  .scenario-card{display:flex; flex-direction:column; gap:12px;}
+  .scenario-grid{display:flex; flex-direction:column; gap:12px; margin-top:12px;}
+  .scenario-card{display:flex; flex-direction:column; gap:12px; cursor:pointer; transition:border-color .15s ease, box-shadow .15s ease;}
+  .scenario-card:hover{border-color:var(--accent); box-shadow:0 0 0 3px rgba(124,196,255,.08);}
+  .scenario-card:focus-visible{outline:2px solid var(--accent); outline-offset:2px;}
   .scenario-card .top{display:flex; justify-content:space-between; align-items:flex-start; gap:12px;}
   .scenario-name{font-size:16px; font-weight:600;}
   .scenario-updated{font-size:12px; color:var(--muted); margin-top:2px;}
-  .scenario-metrics{display:grid; gap:12px; grid-template-columns:repeat(2, minmax(0, 1fr));}
+  .scenario-description{font-size:13px; color:var(--muted); margin:0; line-height:1.5;}
+  .scenario-metrics{display:grid; gap:12px; grid-template-columns:repeat(auto-fit, minmax(160px, 1fr));}
   .scenario-metrics .metric{background:#0f1930; border:1px solid var(--border); border-radius:12px; padding:10px;}
   .scenario-metrics .label{font-size:12px; color:var(--muted);}
   .scenario-metrics .value{font-size:16px; font-weight:700; margin-top:6px;}
   .scenario-metrics .value.positive{color:var(--ok);}
   .scenario-metrics .value.negative{color:var(--danger);}
-  .scenario-card .card-actions{display:flex; gap:8px; flex-wrap:wrap; margin-top:auto;}
+  .scenario-card .card-actions{display:flex; align-items:flex-start; margin-top:auto; position:relative;}
+  .scenario-card .card-actions button{cursor:pointer;}
+  .icon-btn{appearance:none; border:1px solid var(--border); background:#0f1930; color:var(--muted); width:30px; height:30px; border-radius:10px; display:inline-flex; align-items:center; justify-content:center; font-size:18px; line-height:1; transition:.15s ease;}
+  .icon-btn:hover, .icon-btn[aria-expanded="true"]{border-color:var(--accent); color:var(--accent); box-shadow:0 0 0 3px rgba(124,196,255,.08);}
+  .scenario-menu{position:relative;}
+  .scenario-menu-list{position:absolute; top:36px; right:0; background:#0f1930; border:1px solid var(--border); border-radius:12px; min-width:160px; display:flex; flex-direction:column; padding:6px 0; box-shadow:0 18px 35px rgba(5,17,34,.45); z-index:20;}
+  .scenario-menu-list[hidden]{display:none;}
+  .scenario-menu-list button{appearance:none; background:transparent; border:0; color:var(--text); text-align:left; padding:8px 14px; font:inherit; cursor:pointer; display:flex; justify-content:space-between; gap:12px;}
+  .scenario-menu-list button:hover{background:rgba(124,196,255,.12); color:var(--accent);}
+  .scenario-menu-list button.danger{color:#ffb1b1;}
+  .scenario-menu-list button.danger:hover{background:rgba(255,124,124,.12); color:#ff7c7c;}
   #scenario-empty{margin-top:16px;}
+  #view-detail{display:flex; flex-direction:column; gap:20px;}
+  #view-detail .grid{margin-top:0;}
+  .value-display{display:flex; align-items:center; justify-content:flex-end; font-weight:600; padding:4px 0;}
 
 </style>
 </head>
@@ -96,15 +117,23 @@ table{width:100%; border-collapse:collapse;} thead th{position:sticky; top:0; ba
   </header>
 
   <main class="container" id="view-dashboard" style="padding-top:10px">
-    <section class="card">
-      <h2>Scenario Overview</h2>
-      <p class="sub">Compare scenarios at a glance. Select a scenario to open detailed inputs and continue editing.</p>
-      <div id="scenario-list" class="scenario-grid"></div>
-      <p class="small muted" id="scenario-empty" hidden>No scenarios yet. Create one to get started.</p>
-    </section>
+    <div id="scenario-list" class="scenario-grid"></div>
+    <p class="small muted" id="scenario-empty" hidden>No scenarios yet. Create one to get started.</p>
   </main>
 
   <main class="container" id="view-detail" style="padding-top:10px">
+    <section class="card" id="scenario-meta">
+      <h2>Scenario Details</h2>
+      <p class="sub">Name and describe this scenario so it's easy to find later.</p>
+      <div class="form-field">
+        <label for="scenario_name">Name</label>
+        <input type="text" id="scenario_name" placeholder="e.g. High demand" maxlength="120">
+      </div>
+      <div class="form-field">
+        <label for="scenario_description">Description</label>
+        <textarea id="scenario_description" placeholder="Add context about the assumptions" maxlength="500"></textarea>
+      </div>
+    </section>
     <section class="card" id="summary">
       <h2>Summary</h2>
       <p class="sub">Tweak inputs on the left. This recalculates <em>throughput, revenue, COGS, energy, salaries,</em> and <em>EBITDA</em> live. Values use Indian locale formatting.</p>
@@ -118,7 +147,7 @@ table{width:100%; border-collapse:collapse;} thead th{position:sticky; top:0; ba
         <div class="kpi"><div class="label">GM / kg flour</div><div class="value" id="kpi-gmkg">–</div></div>
         <div class="kpi"><div class="label">Break-even flour price (₹/kg)</div><div class="value" id="kpi-breakeven">–</div></div>
       </div>
-    </section><div class="grid" style="margin-top:16px">
+    </section><div class="grid">
   <!-- LEFT: INPUTS -->
   <section class="card">
     <h2>Inputs</h2>
@@ -263,36 +292,36 @@ table{width:100%; border-collapse:collapse;} thead th{position:sticky; top:0; ba
     <h2>Results</h2>
     <p class="sub">Unit economics are based on flour output only (bran is treated as a by‑product credit in revenue).</p>
 
-    <div class="row"><label>Processed (t/month)</label><input id="out_proc_t" type="text" class="mono" readonly></div>
-    <div class="row"><label>Flour output (t/month)</label><input id="out_flour_t" type="text" class="mono" readonly></div>
-    <div class="row"><label>Bran output (t/month)</label><input id="out_bran_t" type="text" class="mono" readonly></div>
+    <div class="row"><label>Processed (t/month)</label><div id="out_proc_t" class="value-display mono">–</div></div>
+    <div class="row"><label>Flour output (t/month)</label><div id="out_flour_t" class="value-display mono">–</div></div>
+    <div class="row"><label>Bran output (t/month)</label><div id="out_bran_t" class="value-display mono">–</div></div>
 
     <hr style="border:0; border-top:1px solid var(--border); margin:14px 0">
 
     <h3>Revenue</h3>
-    <div class="row"><label>Flour revenue</label><input id="rev_flour" type="text" class="mono" readonly></div>
-    <div class="row"><label>Bran revenue</label><input id="rev_bran" type="text" class="mono" readonly></div>
-    <div class="row"><label><strong>Total revenue</strong></label><input id="rev_total" type="text" class="mono" readonly></div>
+    <div class="row"><label>Flour revenue</label><div id="rev_flour" class="value-display mono">–</div></div>
+    <div class="row"><label>Bran revenue</label><div id="rev_bran" class="value-display mono">–</div></div>
+    <div class="row"><label><strong>Total revenue</strong></label><div id="rev_total" class="value-display mono">–</div></div>
 
     <h3 style="margin-top:10px">COGS (Variable)</h3>
-    <div class="row"><label>Wheat cost</label><input id="c_wheat" type="text" class="mono" readonly></div>
-    <div class="row"><label>Packaging</label><input id="c_pack" type="text" class="mono" readonly></div>
-    <div class="row"><label>Energy (machines)</label><input id="c_energy" type="text" class="mono" readonly></div>
-    <div class="row"><label>Other variable</label><input id="c_var" type="text" class="mono" readonly></div>
-    <div class="row"><label><strong>Total COGS</strong></label><input id="c_total" type="text" class="mono" readonly></div>
+    <div class="row"><label>Wheat cost</label><div id="c_wheat" class="value-display mono">–</div></div>
+    <div class="row"><label>Packaging</label><div id="c_pack" class="value-display mono">–</div></div>
+    <div class="row"><label>Energy (machines)</label><div id="c_energy" class="value-display mono">–</div></div>
+    <div class="row"><label>Other variable</label><div id="c_var" class="value-display mono">–</div></div>
+    <div class="row"><label><strong>Total COGS</strong></label><div id="c_total" class="value-display mono">–</div></div>
 
     <h3 style="margin-top:10px">Operating Expenses (Fixed)</h3>
-    <div class="row"><label>Salaries & wages</label><input id="o_salaries" type="text" class="mono" readonly></div>
-    <div class="row"><label>Fixed monthly costs</label><input id="o_fixed" type="text" class="mono" readonly></div>
-    <div class="row"><label>Demand charges</label><input id="o_demand" type="text" class="mono" readonly></div>
-    <div class="row"><label><strong>Total Opex</strong></label><input id="o_total" type="text" class="mono" readonly></div>
+    <div class="row"><label>Salaries & wages</label><div id="o_salaries" class="value-display mono">–</div></div>
+    <div class="row"><label>Fixed monthly costs</label><div id="o_fixed" class="value-display mono">–</div></div>
+    <div class="row"><label>Demand charges</label><div id="o_demand" class="value-display mono">–</div></div>
+    <div class="row"><label><strong>Total Opex</strong></label><div id="o_total" class="value-display mono">–</div></div>
 
     <hr style="border:0; border-top:1px solid var(--border); margin:14px 0">
-    <div class="row"><label><strong>Gross Margin</strong></label><input id="gm" type="text" class="mono" readonly></div>
-    <div class="row"><label><strong>EBITDA</strong></label><input id="ebitda" type="text" class="mono" readonly></div>
-    <div class="row"><label>GM / kg flour</label><input id="gm_perkg" type="text" class="mono" readonly></div>
-    <div class="row"><label>EBITDA / kg flour</label><input id="ebitda_perkg" type="text" class="mono" readonly></div>
-    <div class="row"><label>Break-even flour price (₹/kg)</label><input id="breakeven_price" type="text" class="mono" readonly></div>
+    <div class="row"><label><strong>Gross Margin</strong></label><div id="gm" class="value-display mono">–</div></div>
+    <div class="row"><label><strong>EBITDA</strong></label><div id="ebitda" class="value-display mono">–</div></div>
+    <div class="row"><label>GM / kg flour</label><div id="gm_perkg" class="value-display mono">–</div></div>
+    <div class="row"><label>EBITDA / kg flour</label><div id="ebitda_perkg" class="value-display mono">–</div></div>
+    <div class="row"><label>Break-even flour price (₹/kg)</label><div id="breakeven_price" class="value-display mono">–</div></div>
 
     <details style="margin-top:12px"><summary><strong>Sensitivity (quick what‑ifs)</strong></summary>
       <div class="row"><label>± Wheat price (%)</label><input type="number" id="s_wheat_pct" value="10" step="1"></div>
@@ -358,6 +387,8 @@ table{width:100%; border-collapse:collapse;} thead th{position:sticky; top:0; ba
   const pageTitle = qs('#page-title');
   const dashboardList = qs('#scenario-list');
   const dashboardEmpty = qs('#scenario-empty');
+  const scenarioNameInput = qs('#scenario_name');
+  const scenarioDescriptionInput = qs('#scenario_description');
 
   let scenarios = [];
   let currentScenarioId = null;
@@ -541,6 +572,7 @@ table{width:100%; border-collapse:collapse;} thead th{position:sticky; top:0; ba
           return parsed.map(item=>({
             id: item && item.id ? item.id : newId(),
             name: item && item.name ? String(item.name) : 'Scenario',
+            description: item && item.description ? String(item.description) : '',
             state: ensureStateShape(item && item.state),
             createdAt: item && item.createdAt ? item.createdAt : Date.now(),
             updatedAt: item && item.updatedAt ? item.updatedAt : (item && item.createdAt ? item.createdAt : Date.now())
@@ -555,6 +587,7 @@ table{width:100%; border-collapse:collapse;} thead th{position:sticky; top:0; ba
       return [{
         id: newId(),
         name: 'Base Scenario',
+        description: '',
         state: legacy,
         createdAt: ts,
         updatedAt: ts
@@ -564,6 +597,7 @@ table{width:100%; border-collapse:collapse;} thead th{position:sticky; top:0; ba
     return [{
       id: newId(),
       name: 'Base Scenario',
+      description: '',
       state: ensureStateShape(defaultState()),
       createdAt: ts,
       updatedAt: ts
@@ -589,8 +623,41 @@ table{width:100%; border-collapse:collapse;} thead th{position:sticky; top:0; ba
     setTimeout(()=>URL.revokeObjectURL(url), 1000);
   }
 
+  function buildScenarioSummaryLines(scenario, out){
+    const lines = [];
+    if(scenario){
+      lines.push(`Scenario,${String(scenario.name).replace(/,/g,'')}`);
+    }
+    const add = (key, value) => lines.push(`${key},${String(value).replace(/,/g,'')}`);
+    add('Throughput_t_per_month', out.processed_t);
+    add('Flour_t', out.flour_t);
+    add('Bran_t', out.bran_t);
+    add('Revenue_total', out.rev_total);
+    add('COGS_total', out.c_total);
+    add('GM', out.gm);
+    add('Opex_total', out.o_total);
+    add('EBITDA', out.ebitda);
+    add('GM_perkg', out.gm_perkg);
+    add('EBITDA_perkg', out.ebitda_perkg);
+    add('BreakEven_flour_price_perkg', out.break_even);
+    add('Energy_kWh', out.m_kwh_total);
+    add('Energy_cost', out.c_energy);
+    return lines;
+  }
+
+  function closeAllScenarioMenus(){
+    qsa('.scenario-menu-list').forEach(menu=>{
+      menu.hidden = true;
+      const toggle = menu.parentElement ? menu.parentElement.querySelector('[data-menu-toggle]') : null;
+      if(toggle){
+        toggle.setAttribute('aria-expanded', 'false');
+      }
+    });
+  }
+
   function renderScenarioDashboard(){
     if(!dashboardList) return;
+    closeAllScenarioMenus();
     dashboardList.innerHTML = '';
     if(!scenarios.length){
       if(dashboardEmpty){ dashboardEmpty.hidden = false; }
@@ -601,31 +668,60 @@ table{width:100%; border-collapse:collapse;} thead th{position:sticky; top:0; ba
       const out = compute(s.state);
       const card = document.createElement('article');
       card.className = 'scenario-card card';
+      card.dataset.id = s.id;
+      card.tabIndex = 0;
+      card.setAttribute('role', 'button');
+      card.setAttribute('aria-label', `Open ${s.name}`);
+      const description = s.description ? `<p class="scenario-description">${escapeHtml(s.description).replace(/\n/g,'<br>')}</p>` : '';
+      const ebitdaClass = out.ebitda >= 0 ? 'positive' : 'negative';
       card.innerHTML = `
         <div class="top">
           <div>
             <div class="scenario-name">${escapeHtml(s.name)}</div>
             <div class="scenario-updated">Updated ${escapeHtml(formatUpdated(s.updatedAt))}</div>
           </div>
-          <div class="card-actions">
-            <button class="btn primary" data-action="open" data-id="${s.id}">Open</button>
-            <button class="btn ghost" data-action="duplicate" data-id="${s.id}">Duplicate</button>
+          <div class="card-actions scenario-menu">
+            <button class="icon-btn" aria-haspopup="true" aria-expanded="false" aria-label="Scenario actions" data-menu-toggle data-id="${s.id}">⋮</button>
+            <div class="scenario-menu-list" hidden>
+              <button data-menu-action="duplicate" data-id="${s.id}">Duplicate</button>
+              <button data-menu-action="export" data-id="${s.id}">Download CSV</button>
+              <button class="danger" data-menu-action="delete" data-id="${s.id}">Delete</button>
+            </div>
           </div>
         </div>
+        ${description}
         <div class="scenario-metrics">
+          <div class="metric">
+            <div class="label">Throughput (t/month)</div>
+            <div class="value">${NUM.format(out.processed_t)}</div>
+          </div>
+          <div class="metric">
+            <div class="label">Revenue / month</div>
+            <div class="value">${INR.format(out.rev_total)}</div>
+          </div>
           <div class="metric">
             <div class="label">COGS / month</div>
             <div class="value">${INR.format(out.c_total)}</div>
           </div>
           <div class="metric">
             <div class="label">EBITDA / month</div>
-            <div class="value ${out.ebitda >= 0 ? 'positive' : 'negative'}">${INR.format(out.ebitda)}</div>
+            <div class="value ${ebitdaClass}">${INR.format(out.ebitda)}</div>
           </div>
         </div>
       `;
       card.addEventListener('click', evt=>{
-        if(evt.target.closest('button')) return;
+        if(evt.defaultPrevented) return;
+        if(evt.target.closest('.scenario-menu')) return;
+        closeAllScenarioMenus();
         openScenario(s.id);
+      });
+      card.addEventListener('keydown', evt=>{
+        if(evt.target.closest('.scenario-menu')) return;
+        if(evt.key === 'Enter' || evt.key === ' '){
+          evt.preventDefault();
+          closeAllScenarioMenus();
+          openScenario(s.id);
+        }
       });
       dashboardList.appendChild(card);
     });
@@ -646,6 +742,7 @@ table{width:100%; border-collapse:collapse;} thead th{position:sticky; top:0; ba
   }
 
   function openScenario(id){
+    closeAllScenarioMenus();
     const scenario = scenarios.find(s=>s.id === id);
     if(!scenario) return;
     if(currentScenarioId && currentScenarioId !== id && hasUnsavedChanges){
@@ -656,6 +753,7 @@ table{width:100%; border-collapse:collapse;} thead th{position:sticky; top:0; ba
     document.body.dataset.view = 'scenario';
     pageTitle.textContent = `Flour Mill – ${scenario.name}`;
     updateDocumentTitle();
+    setScenarioMeta(scenario);
     setInputs(ensureStateShape(scenario.state));
     markSaved();
     recalc();
@@ -665,6 +763,32 @@ table{width:100%; border-collapse:collapse;} thead th{position:sticky; top:0; ba
     if(!currentScenarioId) return;
     markDirty();
     recalc();
+  };
+
+  const handleScenarioMetaChange = evt =>{
+    if(!currentScenarioId) return;
+    markDirty();
+    const scenario = currentScenario();
+    if(evt && evt.target === scenarioNameInput){
+      const displayName = scenarioNameInput.value.trim() || 'Scenario';
+      pageTitle.textContent = `Flour Mill – ${displayName}`;
+      document.title = `Flour Mill – ${displayName}`;
+      if(scenario){
+        scenario.name = displayName;
+      }
+    }else if(evt && evt.target === scenarioDescriptionInput){
+      if(scenario){
+        scenario.description = scenarioDescriptionInput.value;
+      }
+    }
+  };
+
+  const handleScenarioNameBlur = ()=>{
+    if(!currentScenarioId || !scenarioNameInput) return;
+    if(!scenarioNameInput.value.trim()){
+      scenarioNameInput.value = 'Scenario';
+      handleScenarioMetaChange({ target: scenarioNameInput });
+    }
   };
 
   function machineRow(m){
@@ -775,6 +899,15 @@ table{width:100%; border-collapse:collapse;} thead th{position:sticky; top:0; ba
     (st.fixed||[]).forEach(f=> fBody.appendChild(fixedRow(f)) );
   }
 
+  function setScenarioMeta(scenario){
+    if(scenarioNameInput){
+      scenarioNameInput.value = scenario && scenario.name ? scenario.name : 'Scenario';
+    }
+    if(scenarioDescriptionInput){
+      scenarioDescriptionInput.value = scenario && scenario.description ? scenario.description : '';
+    }
+  }
+
   function compute(state){
     const processed_t = state.cap_tpd * state.op_days * (state.util_pct/100);
     const flour_t = processed_t * (state.extraction_pct/100);
@@ -836,30 +969,30 @@ table{width:100%; border-collapse:collapse;} thead th{position:sticky; top:0; ba
     qs('#kpi-gmkg').textContent = `₹ ${NUM.format(out.gm_perkg)}`;
     qs('#kpi-breakeven').textContent = `₹ ${NUM.format(out.break_even)}`;
 
-    qs('#out_proc_t').value = NUM.format(out.processed_t);
-    qs('#out_flour_t').value = NUM.format(out.flour_t);
-    qs('#out_bran_t').value  = NUM.format(out.bran_t);
+    qs('#out_proc_t').textContent = NUM.format(out.processed_t);
+    qs('#out_flour_t').textContent = NUM.format(out.flour_t);
+    qs('#out_bran_t').textContent  = NUM.format(out.bran_t);
 
-    qs('#rev_flour').value = INR.format(out.rev_flour);
-    qs('#rev_bran').value  = INR.format(out.rev_bran);
-    qs('#rev_total').value = INR.format(out.rev_total);
+    qs('#rev_flour').textContent = INR.format(out.rev_flour);
+    qs('#rev_bran').textContent  = INR.format(out.rev_bran);
+    qs('#rev_total').textContent = INR.format(out.rev_total);
 
-    qs('#c_wheat').value = INR.format(out.c_wheat);
-    qs('#c_pack').value  = INR.format(out.c_pack);
-    qs('#c_energy').value= INR.format(out.c_energy);
-    qs('#c_var').value   = INR.format(out.c_var);
-    qs('#c_total').value = INR.format(out.c_total);
+    qs('#c_wheat').textContent = INR.format(out.c_wheat);
+    qs('#c_pack').textContent  = INR.format(out.c_pack);
+    qs('#c_energy').textContent= INR.format(out.c_energy);
+    qs('#c_var').textContent   = INR.format(out.c_var);
+    qs('#c_total').textContent = INR.format(out.c_total);
 
-    qs('#o_salaries').value = INR.format(out.s_total);
-    qs('#o_fixed').value    = INR.format(out.f_total);
-    qs('#o_demand').value   = INR.format(out.demand);
-    qs('#o_total').value    = INR.format(out.o_total);
+    qs('#o_salaries').textContent = INR.format(out.s_total);
+    qs('#o_fixed').textContent    = INR.format(out.f_total);
+    qs('#o_demand').textContent   = INR.format(out.demand);
+    qs('#o_total').textContent    = INR.format(out.o_total);
 
-    qs('#gm').value = INR.format(out.gm);
-    qs('#ebitda').value = INR.format(out.ebitda);
-    qs('#gm_perkg').value = `₹ ${NUM.format(out.gm_perkg)}`;
-    qs('#ebitda_perkg').value = `₹ ${NUM.format(out.ebitda_perkg)}`;
-    qs('#breakeven_price').value = `₹ ${NUM.format(out.break_even)}`;
+    qs('#gm').textContent = INR.format(out.gm);
+    qs('#ebitda').textContent = INR.format(out.ebitda);
+    qs('#gm_perkg').textContent = `₹ ${NUM.format(out.gm_perkg)}`;
+    qs('#ebitda_perkg').textContent = `₹ ${NUM.format(out.ebitda_perkg)}`;
+    qs('#breakeven_price').textContent = `₹ ${NUM.format(out.break_even)}`;
 
     const tariff = px(qs('#power_tariff').value);
     let kwhTotal=0, costTotal=0;
@@ -919,11 +1052,24 @@ table{width:100%; border-collapse:collapse;} thead th{position:sticky; top:0; ba
     const state = collectState();
     const out = compute(state);
     render(state, out);
+    const name = scenarioNameInput ? scenarioNameInput.value.trim() : '';
+    const description = scenarioDescriptionInput ? scenarioDescriptionInput.value.trim() : '';
+    const displayName = name || 'Scenario';
+    if(scenarioNameInput){
+      scenarioNameInput.value = displayName;
+    }
+    scenarios[idx].name = displayName;
+    scenarios[idx].description = description;
+    if(scenarioDescriptionInput){
+      scenarioDescriptionInput.value = description;
+    }
     scenarios[idx].state = cloneState(state);
     scenarios[idx].updatedAt = Date.now();
     saveScenarios();
     renderScenarioDashboard();
     updateScenarioTag(out);
+    pageTitle.textContent = `Flour Mill – ${displayName}`;
+    updateDocumentTitle();
     hasUnsavedChanges = false;
     return out;
   }
@@ -933,6 +1079,7 @@ table{width:100%; border-collapse:collapse;} thead th{position:sticky; top:0; ba
     const scenario = {
       id: newId(),
       name: uniqueScenarioName('Scenario'),
+      description: '',
       state: ensureStateShape(defaultState()),
       createdAt: ts,
       updatedAt: ts
@@ -947,10 +1094,16 @@ table{width:100%; border-collapse:collapse;} thead th{position:sticky; top:0; ba
     const base = scenarios.find(s=>s.id === id);
     let sourceState = null;
     let sourceName = base ? base.name : 'Scenario';
+    let sourceDescription = base && base.description ? String(base.description) : '';
     if(currentScenarioId === id){
       sourceState = collectState();
       const current = currentScenario();
       if(current && current.name) sourceName = current.name;
+      if(scenarioDescriptionInput){
+        sourceDescription = scenarioDescriptionInput.value.trim();
+      }else if(current && current.description){
+        sourceDescription = current.description;
+      }
     }else if(base){
       sourceState = cloneState(base.state);
     }
@@ -959,6 +1112,7 @@ table{width:100%; border-collapse:collapse;} thead th{position:sticky; top:0; ba
     const scenario = {
       id: newId(),
       name: uniqueScenarioName(`${sourceName} Copy`),
+      description: sourceDescription,
       state: ensureStateShape(sourceState),
       createdAt: ts,
       updatedAt: ts
@@ -967,6 +1121,38 @@ table{width:100%; border-collapse:collapse;} thead th{position:sticky; top:0; ba
     saveScenarios();
     renderScenarioDashboard();
     openScenario(scenario.id);
+  }
+
+  function exportScenarioSummary(id){
+    const scenario = scenarios.find(s=>s.id === id);
+    if(!scenario) return;
+    let state = null;
+    if(currentScenarioId === id){
+      state = collectState();
+    }else{
+      state = ensureStateShape(scenario.state);
+    }
+    const out = compute(state);
+    const lines = buildScenarioSummaryLines(scenario, out);
+    const slug = slugify(scenario.name || 'scenario') || 'scenario';
+    downloadCsv(`flourmill_monthly_summary_${slug}.csv`, lines);
+  }
+
+  function deleteScenario(id){
+    const idx = scenarios.findIndex(s=>s.id === id);
+    if(idx === -1) return;
+    const name = scenarios[idx].name || 'Scenario';
+    if(!confirm(`Delete "${name}"? This cannot be undone.`)) return;
+    const deletingCurrent = currentScenarioId === id;
+    scenarios.splice(idx, 1);
+    saveScenarios();
+    if(deletingCurrent){
+      currentScenarioId = null;
+      hasUnsavedChanges = false;
+      showDashboard();
+    }else{
+      renderScenarioDashboard();
+    }
   }
 
   function exportAllScenarios(){
@@ -1001,16 +1187,52 @@ table{width:100%; border-collapse:collapse;} thead th{position:sticky; top:0; ba
 
   if(dashboardList){
     dashboardList.addEventListener('click', evt=>{
-      const btn = evt.target.closest('button[data-action]');
-      if(!btn) return;
-      const id = btn.getAttribute('data-id');
-      if(!id) return;
-      if(btn.dataset.action === 'open'){
-        openScenario(id);
-      }else if(btn.dataset.action === 'duplicate'){
-        duplicateScenario(id);
+      const toggle = evt.target.closest('[data-menu-toggle]');
+      if(toggle){
+        evt.stopPropagation();
+        const menu = toggle.parentElement.querySelector('.scenario-menu-list');
+        if(!menu) return;
+        const expanded = toggle.getAttribute('aria-expanded') === 'true';
+        closeAllScenarioMenus();
+        if(!expanded){
+          menu.hidden = false;
+          toggle.setAttribute('aria-expanded', 'true');
+        }
+        return;
       }
+
+      const actionBtn = evt.target.closest('[data-menu-action]');
+      if(actionBtn){
+        evt.stopPropagation();
+        const id = actionBtn.getAttribute('data-id');
+        if(!id) return;
+        closeAllScenarioMenus();
+        if(actionBtn.dataset.menuAction === 'duplicate'){
+          duplicateScenario(id);
+        }else if(actionBtn.dataset.menuAction === 'export'){
+          exportScenarioSummary(id);
+        }else if(actionBtn.dataset.menuAction === 'delete'){
+          deleteScenario(id);
+        }
+        return;
+      }
+
     });
+  }
+
+  document.addEventListener('click', evt=>{
+    if(!evt.target.closest('.scenario-menu')){
+      closeAllScenarioMenus();
+    }
+  });
+
+  if(scenarioNameInput){
+    scenarioNameInput.addEventListener('input', handleScenarioMetaChange);
+    scenarioNameInput.addEventListener('blur', handleScenarioNameBlur);
+  }
+
+  if(scenarioDescriptionInput){
+    scenarioDescriptionInput.addEventListener('input', handleScenarioMetaChange);
   }
 
   if(btnBack){
@@ -1068,19 +1290,7 @@ table{width:100%; border-collapse:collapse;} thead th{position:sticky; top:0; ba
       const out = compute(state);
       render(state, out);
       const scenario = currentScenario();
-      const lines = [];
-      if(scenario){
-        lines.push(`Scenario,${String(scenario.name).replace(/,/g,'')}`);
-      }
-      const add=(k,v)=>lines.push(`${k},${String(v).replace(/,/g,'')}`);
-      add('Throughput_t_per_month', out.processed_t);
-      add('Flour_t', out.flour_t); add('Bran_t', out.bran_t);
-      add('Revenue_total', out.rev_total);
-      add('COGS_total', out.c_total);
-      add('GM', out.gm); add('Opex_total', out.o_total); add('EBITDA', out.ebitda);
-      add('GM_perkg', out.gm_perkg); add('EBITDA_perkg', out.ebitda_perkg);
-      add('BreakEven_flour_price_perkg', out.break_even);
-      add('Energy_kWh', out.m_kwh_total); add('Energy_cost', out.c_energy);
+      const lines = buildScenarioSummaryLines(scenario, out);
       const slug = slugify(scenario ? scenario.name : 'scenario') || 'scenario';
       downloadCsv(`flourmill_monthly_summary_${slug}.csv`, lines);
     });


### PR DESCRIPTION
## Summary
- make each scenario card act like a keyboard-accessible button so clicking anywhere outside the overflow menu opens the scenario reliably
- close open overflow menus when activating a scenario and add a visible focus outline for cards to clarify interactivity

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df55af4fa48333af5561ef14c1d5ca